### PR TITLE
Remote debugging with jsconsole.com for Windows Phones

### DIFF
--- a/src/init.coffee
+++ b/src/init.coffee
@@ -1,11 +1,20 @@
 
 $(document).bind "mobileinit", ->
-    console.log "mobileinit"
+    if !window.console
+      console =
+        log: ->
+      window.console = console
+      $.ajaxSetup({cache: true});
+      $.getScript("http://jsconsole.com/remote.js?citynavi")
+     else
+       window.console.log "mobileinit"
     $.mobile.defaultPageTransition = "slide"
     $.mobile.defaultHomeScroll = 0
 
     # non-native inputs don't work in leaflet
     $.mobile.page.prototype.options.keepNative = "form input"
+
+
 
 $(document).ajaxStart (e) ->
     $.mobile.loading('show')


### PR DESCRIPTION
If window.console has not been defined, defines empty function for it and tries to connect to jsconsole.com for remote logging. Makes logging possible with Windows Phone (tested with Nokia Lumia 900/Windows Phone 7.5).
