### PR TITLE
Move charset to precede <title>.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Navigator</title>
-
         <meta charset='utf-8'>
+        <title>Navigator</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <link rel="stylesheet" href="static/css/jquery.mobile-1.3.1.min.css" />


### PR DESCRIPTION
As referred to in the documentation for h5bp[1], charset should be
defined before <title>. I think the security issue does not apply to the
current form of our project but if we would later dynamically change the
title to match a local language, for example, we might create a
vulnerability. Or perhaps we will create a very long title in the future
so that charset would be pushed beyond the limit of 1024 bytes. ;)

[1] https://github.com/h5bp/mobile-boilerplate/blob/v4.1.0/doc/html.md#the-order-of-meta-tags-and-title
