### PR TITLE
Add png icon support for browsers that don't support svg files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ log.html
 report.html
 output.xml
 selenium-screenshot-*.png
+static/images/grunticon/
+static/images/modified_helper/hashes.json

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -16,8 +16,9 @@ module.exports = (grunt) ->
       files: [
         'Gruntfile.coffee'
         'src/*.coffee'
+        'static/images/*.svg'
       ]
-      tasks: 'default'
+      tasks: ['default', 'iconifmodified']
 
     testem:
       headless:
@@ -71,17 +72,33 @@ module.exports = (grunt) ->
         options:
           port: 9001
           base: "."
-
+    grunticon:
+      city_nav_icons:
+        options:
+          src: "static/images/"
+          dest: "static/images/grunticon/"
+    iconifmodified:
+      options:
+        hashFile: 'static/images/modified_helper/hashes.json'
+      grunticon:
+        src: ['static/images/*.svg']
+        options:
+          tasks: ['grunticon']
+          
   grunt.loadNpmTasks 'grunt-contrib-coffee'
   grunt.loadNpmTasks 'grunt-contrib-watch'
   grunt.loadNpmTasks 'grunt-contrib-connect'
   grunt.loadNpmTasks 'grunt-exec'
   grunt.loadNpmTasks 'grunt-testem'
+  grunt.loadNpmTasks 'grunt-grunticon'
 
+  grunt.loadTasks 'static/images/modified_helper'
+  
   grunt.registerTask 'default', ['coffee']
-  grunt.registerTask 'server', ['coffee', 'connect', 'watch']
+  grunt.registerTask 'server', ['coffee', 'iconifmodified', 'connect', 'watch']
   grunt.registerTask 'test', ['coffee', 'testem:headless']
   grunt.registerTask 'test-desktop', ['coffee', 'testem:desktop']
   grunt.registerTask 'test-mobile', ['coffee', 'testem:mobile']
   grunt.registerTask 'test-robot', ['coffee', 'connect', 'exec:robot']
   grunt.registerTask 'test-robot-desktop', ['coffee', 'connect', 'exec:robot_desktop']
+  grunt.registerTask 'icon', ['iconifmodified']

--- a/README.md
+++ b/README.md
@@ -104,3 +104,23 @@ detected.
 Run ``python bootstrap.py --version 2.1.1`` and ``bin/buildout``.
 
 Run ``grunt test-robot-desktop``.
+
+## Using icons ##
+
+Add svg file(s) under folder `./static/images` that has been defined to be used in `Gruntfile.coffee` and
+in `src/config.coffee`.  Run `grunt icon` to generate the png files.
+
+In code, use `citynavicon.get_icon_path("myicon")` to get path to image that
+you can, for example use as src attribute in an img html element. Alternatively, you
+can use `citynavicon.get_icon_html(name, [attribute_string])` function to get an img element
+with the specified name and with an optional attribute_string such as
+``style="height: 20px" class="ui-li-icon"``. Finally, in the index.html
+you can include images via defining img element with class="citynavicon-myicon" where
+"citynavicon-" is mandatory part and "myicon" specifies name of the image. The class definitions
+are applied when `iconprovider.modify_img_elements()` is called.
+
+Note that svg files should define svg as default namespace for grunticon to work at the
+moment. Also note that svg files should define viewBox="0 0 w h" attribute where w and
+h correspond the defined width and height attribute values. The viewBox attribute
+ensures better browser compatability. For more information,
+see http://www.seowarp.com/blog/2011/06/svg-scaling-problems-in-ie9-and-other-browsers/.

--- a/index.html
+++ b/index.html
@@ -64,12 +64,12 @@
             </div>
             <div data-role="content" style="position: absolute; width: 100%; bottom: 0; text-align: center; padding-left: 0; padding-right: 0">
                         <fieldset data-role="controlgroup" data-type="horizontal" data-shadow="true" style="display: inline-block">
-                            <label><input type="checkbox" name="usetransit" checked="checked"><img src="static/images/bus_stop.svg" style="height: 20px;" /></input></label>
+                            <label><input type="checkbox" name="usetransit" checked="checked"><img class="iconprovider-bus_stop" style="height: 20px;" /></input></label>
                         </fieldset>
                         <fieldset id="vehiclesettings" data-role="controlgroup" data-type="horizontal" data-shadow="true" style="display: inline-block">
-                            <label><input type="radio" name="vehiclesettings" value="WALK" checked="checked"><img src="static/images/walking.svg" style="height: 20px;"/></input></label>
-                            <label><input type="radio" name="vehiclesettings" value="BICYCLE"><img src="static/images/bicycle.svg" style="height: 20px;"/></input></label>
-                            <label><input type="radio" name="vehiclesettings" value="CAR"><img src="static/images/car.svg" style="height: 20px;"/></input></label>
+                            <label><input type="radio" name="vehiclesettings" value="WALK" checked="checked"><img class="iconprovider-walking" style="height: 20px;"/></input></label>
+                            <label><input type="radio" name="vehiclesettings" value="BICYCLE"><img class="iconprovider-bicycle" style="height: 20px;"/></input></label>
+                            <label><input type="radio" name="vehiclesettings" value="CAR"><img class="iconprovider-car" style="height: 20px;"/></input></label>
                         </fieldset>
             </div>
             <div id="front-page-menu" data-role="popup">
@@ -210,10 +210,10 @@
                 <ul data-role="listview" style="margin-bottom: 0">
                     <li>
                         <fieldset id="modesettings" data-role="controlgroup" data-type="horizontal">
-                            <label><input type="checkbox" name="BUS"><img src="static/images/bus_stop.svg" style="height: 20px;"/></input></label>
-                            <label><input type="checkbox" name="TRAM"><img src="static/images/tram_stop.svg" style="height: 20px;"/></input></label>
-                            <label><input type="checkbox" name="RAIL"><img src="static/images/train_station2.svg" style="height: 20px;"/></input></label>
-                            <label><input type="checkbox" name="SUBWAY"><img src="static/images/subway.svg" style="height: 20px;"/></input></label>
+                            <label><input type="checkbox" name="BUS"><img class="iconprovider-bus_stop" style="height: 20px;"/></input></label>
+                            <label><input type="checkbox" name="TRAM"><img class="iconprovider-tram_stop" style="height: 20px;"/></input></label>
+                            <label><input type="checkbox" name="RAIL"><img class="iconprovider-train_station2" style="height: 20px;"/></input></label>
+                            <label><input type="checkbox" name="SUBWAY"><img class="iconprovider-subway" style="height: 20px;"/></input></label>
                         </fieldset>
                     </li>
                     <li>
@@ -259,12 +259,23 @@
                 });
             });
         }
+        
+        // Once pages have been created modify their structure for img elements that have the iconprovider class
+        jQuery(document).on('pagecreate', '#front-page', function() {
+            citynavi.iconprovider.modify_img_elements(this);
+        });
+        jQuery(document).on('pagecreate', '#settings', function() {
+            citynavi.iconprovider.modify_img_elements(this);
+        });
+        
         </script>
         <!-- Initialization related code -->
         <script src="static/js/init.js"></script>
         <!-- Configure the geographical area where the app is to be used in -->
         <script src="static/js/config.js"></script>
         <script src="static/js/local_config.js"></script>
+        <!-- Providing svg or png icons depending of the support by the web browser. -->
+        <script src="static/js/iconprovider.js"></script>
         <!-- "Colorful iconic & retina-proof markers for Leaflet,
              based on the Font Awesome/Twitter Bootstrap icons" -->
         <script src="static/js/leaflet-awesome-markers.js"></script>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt-exec": "0.x",
     "grunt-testem": "0.x",
     "mocha": "1.x",
-    "chai": "1.x"
+    "chai": "1.x",
+    "grunt-grunticon": "0.x"
   }
 }

--- a/src/autocomplete.coffee
+++ b/src/autocomplete.coffee
@@ -82,12 +82,12 @@ class Prediction
         name = @name
         if @type == "category" # Prediction is for a category
             dest_page = "select-nearest"
-            icon_html = @category.get_icon_html()
+            icon_html = citynavi.iconprovider.get_icon_html(@category.get_icon_name())
             name = "Closest " + name.toLowerCase() # For example, "Closest library"
         else
             dest_page = "map-page"
         if @location?.icon?
-            icon_html = "<img src='#{@location.icon}'>"
+            icon_html = citynavi.iconprovider.get_icon_html(@location.icon)
         $el = $("<li><a href='##{dest_page}'>#{icon_html}#{name}</a></li>")
         $el.find('img').height(20).addClass('ui-li-icon')
         return $el

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -72,6 +72,7 @@ defaults =
     faye_url: "http://dev.hsl.fi:9002/faye"
 
     icon_base_path: "static/images/"
+    icon_grunticon_png_path: "static/images/grunticon/png/"
 
     colors:
         hsl: hsl_colors
@@ -89,16 +90,16 @@ defaults =
 
     icons:
         google:
-            WALK: 'walking.svg'
-            CAR: 'car.svg'
-            BICYCLE: 'bicycle.svg'
-            WAIT: 'clock.svg'
-            0: 'tram_stop.svg'
-            1: 'subway.svg'
-            2: 'train_station2.svg'
-            3: 'bus_stop.svg'
-            4: 'port.svg'
-            109: 'train_station2.svg'
+            WALK: 'walking'
+            CAR: 'car'
+            BICYCLE: 'bicycle'
+            WAIT: 'clock'
+            0: 'tram_stop'
+            1: 'subway'
+            2: 'train_station2'
+            3: 'bus_stop'
+            4: 'port'
+            109: 'train_station2'
 
     maps:
         cloudmade:

--- a/src/iconprovider.coffee
+++ b/src/iconprovider.coffee
@@ -1,0 +1,39 @@
+{
+    icon_base_path,
+    icon_grunticon_png_path
+} = citynavi.config
+
+# IconProvider is for providing svg or png icons depending of the support by the web browser.
+class IconProvider
+    constructor: (opts) ->
+        _.extend @, opts
+    
+    # Use `citynavicon.get_icon_path("myicon")` to get path to image that
+    # you can, for example use as src attribute in an img html element.   
+    get_icon_path: (name) ->
+        if document.implementation.hasFeature 'http://www.w3.org/TR/SVG11/feature#Image', '1.1' || document.implementation.hasFeature 'org.w3c.dom.svg', '1.0'
+            return icon_base_path + name + '.svg'
+        else
+            return icon_grunticon_png_path + name + '.png'
+    
+    # Use `citynavicon.get_icon_html(name, [attribute_string])` function to get an img element
+    # with the specified name and with an optional attribute_string such as
+    # ``style="height: 20px" class="ui-li-icon"``.
+    get_icon_html: (name, param_string) ->
+        params = param_string ? ''
+        return '<img src="' + @get_icon_path(name) + '"' + params + '>'
+
+    # In html you can include images via defining img element with class="citynavicon-myicon" where
+    # "citynavicon-" is mandatory part and "myicon" specifies name of the image. In addition to defining the class
+    # call the function `modify_img_elements(parent_id)` for the parent with parent_id of the
+    # img element to generate the src attributes for the img elements under the parent.
+    modify_img_elements: (parent_id) ->
+    
+        self = @;
+        
+        $(parent_id).find('img[class*=iconprovider]').each ->
+            $(@).attr 'src', self.get_icon_path($(@).attr('class').substring(13))
+
+
+citynavi.iconprovider = new IconProvider
+

--- a/src/leaflet-awesome-markers.coffee
+++ b/src/leaflet-awesome-markers.coffee
@@ -35,8 +35,8 @@
             div
 
         _createInner: ->
-            if @options.svg?
-                return "<img src='#{@options.svg}' height='18' style='margin-top: 8px; -webkit-filter: invert(1);'>"
+            if @options.topIcon?
+                return "<img src='#{@options.topIcon}' height='18' style='margin-top: 8px; -webkit-filter: invert(1);'>"
             if @options.icon.slice(0, 5) is "icon-"
                 iconClass = @options.icon
             else

--- a/src/poi.coffee
+++ b/src/poi.coffee
@@ -1,8 +1,7 @@
 {
     hel_geocoder_poi_url,
     waag_url,
-    waag_id,
-    icon_base_path
+    waag_id
 } = citynavi.config
 
 class POI
@@ -116,25 +115,23 @@ class POICategory
     set_provider: (provider, provider_args) ->
         @provider = provider
         @provider_args = provider_args
-    get_icon_path: ->
-        return icon_base_path + @icon
-    get_icon_html: ->
-        return '<img src="' + @get_icon_path() + '">'
+    get_icon_name: ->
+        return @icon
     fetch_pois: (opts) ->
         @provider.fetch_pois @, opts
 
 supported_poi_categories = {
-    "library": new POICategory {type: "library", name: "Library", plural_name: "Libraries", icon: "library.svg"}
-    "recycling": new POICategory {type: "recycling", name: "Recycling point", icon: "recycling.svg"}
-    "park": new POICategory {type: "park", name: "Park", icon: "coniferous_and_deciduous.svg", waag_filter: {"osm::leisure": "park"}}
-    "swimming_pool": new POICategory {type: "swimming_pool", name: "Swimming pool", icon: "swimming_indoor.svg"}
-    "cafe": new POICategory {type: "cafe", name: "Cafe", icon: "cafe.svg"}
-    "bar": new POICategory {type: "bar", name: "Bar", icon: "bar.svg"}
-    "pharmacy": new POICategory {type: "pharmacy", name: "Pharmacy", icon: "pharmacy.svg", waag_filter: {"osm::amenity": "pharmacy"}}
-    "toilet": new POICategory {type: "toilet", name: "Toilet (public)", icon: "toilets_men.svg", waag_filter: {"osm::amenity": "toilets"}}
-    "pub": new POICategory {type: "pub", name: "Pub", icon: "pub.svg"}
-    "supermarket": new POICategory {type: "supermarket", name: "Supermarket", icon: "supermarket.svg", waag_filter: {"osm::shop": "supermarket"}}
-    "restaurant": new POICategory {type: "restaurant", name: "Restaurant", icon: "restaurant.svg"}
+    "library": new POICategory {type: "library", name: "Library", plural_name: "Libraries", icon: "library"}
+    "recycling": new POICategory {type: "recycling", name: "Recycling point", icon: "recycling"}
+    "park": new POICategory {type: "park", name: "Park", icon: "coniferous_and_deciduous", waag_filter: {"osm::leisure": "park"}}
+    "swimming_pool": new POICategory {type: "swimming_pool", name: "Swimming pool", icon: "swimming_indoor"}
+    "cafe": new POICategory {type: "cafe", name: "Cafe", icon: "cafe"}
+    "bar": new POICategory {type: "bar", name: "Bar", icon: "bar"}
+    "pharmacy": new POICategory {type: "pharmacy", name: "Pharmacy", icon: "pharmacy", waag_filter: {"osm::amenity": "pharmacy"}}
+    "toilet": new POICategory {type: "toilet", name: "Toilet (public)", icon: "toilets_men", waag_filter: {"osm::amenity": "toilets"}}
+    "pub": new POICategory {type: "pub", name: "Pub", icon: "pub"}
+    "supermarket": new POICategory {type: "supermarket", name: "Supermarket", icon: "supermarket", waag_filter: {"osm::shop": "supermarket"}}
+    "restaurant": new POICategory {type: "restaurant", name: "Restaurant", icon: "restaurant"}
 }
 
 # Go through the list of POI providers and the list of categories under the POI providers:
@@ -196,8 +193,9 @@ $('#service-directory').bind 'pageshow', (e, data) ->
         # e.g. Tampere, in the config.coffee and have been stored to citynavi.poi_categories in
         # this file.
         for category, index in citynavi.poi_categories
-            $list.append("<li><a href=\"#service-list?category=#{index}\"><img src=\"#{category.get_icon_path()}\" class='ui-li-icon' style='height: 20px;'/>#{category.name}</a></li>")
-
+            icon_html = citynavi.iconprovider.get_icon_html(category.get_icon_name(), 'style="height: 20px" class="ui-li-icon"')
+            $list.append("<li><a href=\"#service-list?category=#{index}\">#{icon_html}#{category.name}</a></li>")
+            
 #        setTimeout (() -> $list.listview()), 0
         $list.listview("refresh")
 
@@ -251,7 +249,8 @@ $(document).bind "pagebeforechange", (e, data) ->
                     else
                         dist = Math.round((dist + 10) / 10)
                         dist *= 10
-                    $item = $("<li><a href=\"#map-page\"><img src=\"#{category.get_icon_path()}\" class='ui-li-icon' style=\"height: 20px;\"/>#{poi.name}<span class='ui-li-count'>#{dist} m</span></a></li>")
+                    icon_html = citynavi.iconprovider.get_icon_html(category.get_icon_name(), 'style="height: 20px" class="ui-li-icon"')
+                    $item = $("<li><a href=\"#map-page\">#{icon_html}#{poi.name}<span class='ui-li-count'>#{dist} m</span></a></li>")
 
                     # Bind event handler to the list item
                     $item.click () ->

--- a/src/routing.coffee
+++ b/src/routing.coffee
@@ -258,7 +258,7 @@ route_to_destination = (target_location) ->
         for poi in citynavi.poi_list
           do (poi) ->
             icon = L.AwesomeMarkers.icon
-                svg: poi.category.get_icon_path()
+                topIcon: citynavi.iconprovider.get_icon_path(poi.category.get_icon_name())
                 color: 'green'
             latlng = new L.LatLng(poi.coords[0], poi.coords[1])
             marker = L.marker(latlng, {icon: icon})
@@ -538,7 +538,9 @@ render_route_layer = (itinerary, routeLayer) ->
                 last_stop = leg.to
                 point = {y: stop.lat, x: stop.lon}
                 icon = L.divIcon({className: "navigator-div-icon"})
-                label = "<span style='font-size: 24px; padding-right: 6px'><img src='static/images/#{google_icons[leg.routeType ? leg.mode]}' style='vertical-align: sub; height: 24px '/> #{leg.route}</span>"
+                google_icon = google_icons[leg.routeType ? leg.mode]
+                icon_html = citynavi.iconprovider.get_icon_html(google_icon, "style='vertical-align: sub; height: 24px'")
+                label = "<span style='font-size: 24px; padding-right: 6px'>#{icon_html} #{leg.route}</span>"
 
                 # Define function to calculate the transit arrival time and update the element
                 # that has uid specific to this leg once per second by calling this function
@@ -592,7 +594,8 @@ render_route_layer = (itinerary, routeLayer) ->
                     pos = [msg.position.latitude, msg.position.longitude]
                     if not (id of vehicles) # Data for a new vehicle was given from the server
                         # Draw icon for the vehicle
-                        icon = L.divIcon({className: "navigator-div-icon", html: "<img src='static/images/#{google_icons[leg.routeType ? leg.mode]}' height='20px' />"})
+                        google_icon = google_icons[leg.routeType ? leg.mode]
+                        icon = L.divIcon({className: "navigator-div-icon", html: citynavi.iconprovider.get_icon_html(google_icon, 'height="20px"')})
                         vehicles[id] = L.marker(pos, {icon: icon})
                             .addTo(routeLayer)
                         console.log "new vehicle #{id} on route #{leg.routeId}"
@@ -649,13 +652,14 @@ render_route_buttons = ($list, itinerary, route_layer, polylines) ->
 #    $list.append($full_trip)
 
     # label with itinerary start time
-    $start = $("<li class='leg'><div class='leg-bar'><i><img src='static/images/walking.svg' height='100%' style='visibility: hidden' /></i><div class='leg-indicator' style='font-style: italic; text-align: left'>#{moment(trip_start).format("HH:mm")}</div></div></li>")
+    icon_html = citynavi.iconprovider.get_icon_html('walking', 'height="100%" style="visibility: hidden"')
+    $start = $("<li class='leg'><div class='leg-bar'><i>#{icon_html}</i><div class='leg-indicator' style='font-style: italic; text-align: left'>#{moment(trip_start).format("HH:mm")}</div></div></li>")
     $start.css("left", "#{0}%")
     $start.css("width", "#{10}%")
     $list.append($start)
 
     # label with itinerary end time
-    $end = $("<li class='leg'><div class='leg-bar'><i><img src='static/images/walking.svg' height='100%' style='visibility: hidden' /></i><div class='leg-indicator' style='font-style: italic; text-align: right'>#{moment(trip_start+trip_duration).format("HH:mm")}</div></div></li>")
+    $end = $("<li class='leg'><div class='leg-bar'><i>#{icon_html}</i><div class='leg-indicator' style='font-style: italic; text-align: right'>#{moment(trip_start+trip_duration).format("HH:mm")}</div></div></li>")
     $end.css("right", "#{0}%")
     $end.css("width", "#{10}%")
     $list.append($end)
@@ -667,7 +671,7 @@ render_route_buttons = ($list, itinerary, route_layer, polylines) ->
       do (index) ->
 
         if leg.mode == "WALK" and $('#wheelchair').attr('checked')
-            icon_name = "wheelchair.svg"
+            icon_name = "wheelchair"
         else
             icon_name = google_icons[leg.routeType ? leg.mode]
 
@@ -676,7 +680,7 @@ render_route_buttons = ($list, itinerary, route_layer, polylines) ->
 # GoodEnoughJourneyPlanner style:
         leg_start = (leg.startTime-trip_start)/max_duration
         leg_duration = leg.duration/max_duration
-        leg_label = "<img src='static/images/#{icon_name}' height='100%' />"
+        leg_label = citynavi.iconprovider.get_icon_html(icon_name, 'height="100%"')
 
         # for long non-transit legs, display distance in place of route
         if not leg.routeType? and leg.distance? and leg_duration > 0.2
@@ -687,7 +691,8 @@ render_route_buttons = ($list, itinerary, route_layer, polylines) ->
 # YetAnotherJourneyPlanner style:
 #        leg_start = (index+1)/length # leg_start and leg_duration are used for positioning the buttons.
 #        leg_duration = 1/length
-#        leg_label = "<img src='static/images/#{icon_name}' height='100%' /> #{leg.route}"
+#        icon_html = citynavi.iconprovider.get_icon_html(icon_name, 'height="100%"')
+#        leg_label = "#{icon_html} #{leg.route}"
 #        leg_subscript = "#{Math.ceil(leg.duration/1000/60)}min"
 
         $leg = $("<li class='leg'><div style='background: #{color};' class='leg-bar'><i>#{leg_label}</i>#{leg_subscript}</div></li>")

--- a/static/images/bar.svg
+++ b/static/images/bar.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg:svg
+<svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
@@ -13,7 +13,8 @@
    height="580"
    id="svg2"
    inkscape:version="0.48.1 r9760"
-   sodipodi:docname="food_bar.svg">
+   sodipodi:docname="food_bar.svg"
+   viewBox="0 0 580 580">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -34,7 +35,7 @@
      inkscape:window-y="0"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg2" />
-  <svg:metadata
+  <metadata
      id="metadata2975">
     <RDF>
       <Work
@@ -55,20 +56,20 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
-  </svg:metadata>
-  <svg:defs
+  </metadata>
+  <defs
      id="defs4" />
-  <svg:g
+  <g
      id="g1327">
-    <svg:path
+    <path
        d="M 66.275,1.768 C 24.94,1.768 1.704,23.139 1.704,66.804 l 0,450.123 c 0,40.844 20.894,62.229 62.192,62.229 l 452.024,0 c 41.307,0 62.229,-20.316 62.229,-62.229 l 0,-450.123 c 0,-42.601 -20.922,-65.036 -63.522,-65.036 -0.003,0 -448.494,-0.143 -448.352,0 z"
        style="fill:#111111;stroke:#eeeeee;stroke-width:3.40799999"
        id="path1329"
        inkscape:connector-curvature="0" />
-  </svg:g>
-  <svg:path
+  </g>
+  <path
      d="m 468.232,97.93 -0.251,0 c 0.287,-0.248 0.445,-0.498 0.445,-0.75 0,-5.937 -81.067,-10.75 -181.07,-10.75 -100.002,0 -181.07,4.813 -181.07,10.75 0,0.252 0.158,0.502 0.446,0.75 l -0.446,0 160.474,148.535 0,168.073 -103.962,74.32 0.255,0 c -0.5,0.27 -0.765,0.544 -0.765,0.821 0,4.102 55.996,7.425 125.07,7.425 69.075,0 125.07,-3.323 125.07,-7.425 0,-0.277 -0.266,-0.552 -0.765,-0.821 l 0.06,0 -103.962,-74.32 0,-168.072 L 468.232,97.93 z m -175.71,119.639 c -2.895,2.679 -7.631,2.679 -10.526,0 l -77.535,-71.768 c -2.895,-2.679 -2.036,-4.872 1.909,-4.872 l 161.779,0 c 3.944,0 4.804,2.192 1.909,4.872 l -77.536,71.768 z"
      style="fill:#ffffff"
      id="path2209"
      inkscape:connector-curvature="0" />
-</svg:svg>
+</svg>

--- a/static/images/bicycle.svg
+++ b/static/images/bicycle.svg
@@ -15,7 +15,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.46"
    sodipodi:docname="shopping_bicycle.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <defs
      id="defs22">
     <inkscape:perspective

--- a/static/images/bus_stop.svg
+++ b/static/images/bus_stop.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="highway_bus_stop.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata1976">
     <rdf:RDF>

--- a/static/images/cafe.svg
+++ b/static/images/cafe.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="refreshments.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/car.svg
+++ b/static/images/car.svg
@@ -15,7 +15,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.46"
    sodipodi:docname="shopping_car.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata10">
     <rdf:RDF>

--- a/static/images/clock.svg
+++ b/static/images/clock.svg
@@ -16,7 +16,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.47 r22583"
    sodipodi:docname="tourist_castle2.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/coniferous_and_deciduous.svg
+++ b/static/images/coniferous_and_deciduous.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="landuse_coniferous_and_deciduous.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/library.svg
+++ b/static/images/library.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="library.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/library2.svg
+++ b/static/images/library2.svg
@@ -17,7 +17,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.48.0 r9654"
    sodipodi:docname="amenity_library2.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/modified_helper/iconifmodified.js
+++ b/static/images/modified_helper/iconifmodified.js
@@ -1,0 +1,56 @@
+// Solution from http://stackoverflow.com/questions/17167188/conditionally-running-tasks-in-grunt-if-some-files-are-changed
+
+var fs = require('fs');
+var crypto = require('crypto');
+
+module.exports = function (grunt) {
+
+    grunt.registerMultiTask('iconifmodified', 'Conditionally running tasks if files are changed.', function () {
+
+        var options = this.options({});
+
+        grunt.verbose.writeflags(options, 'Options');
+
+        var hashes = {};
+        if (grunt.file.exists(options.hashFile)) {
+            try {
+                hashes = grunt.file.readJSON(options.hashFile);
+            }
+            catch (err) {
+                grunt.log.warn(err);
+            }
+        }
+        grunt.verbose.writeflags(hashes, 'Hashes');
+
+        var md5 = crypto.createHash('md5');
+
+        this.files.forEach(function (f) {
+            f.src.forEach(function (filepath) {
+                var stats = fs.statSync(filepath);
+                md5.update(JSON.stringify({
+                    filepath: filepath,
+                    isFile: stats.isFile(),
+                    size: stats.size,
+                    ctime: stats.ctime,
+                    mtime: stats.mtime
+                }));
+            });
+        });
+
+        var hash = md5.digest('hex');
+        grunt.verbose.writeln('Hash: ' + hash);
+
+        if (hash != hashes[this.target]) {
+            grunt.log.writeln('Something changed, executing tasks: ' + JSON.stringify(options.tasks));
+
+            grunt.task.run(options.tasks);
+
+            hashes[this.target] = hash;
+            grunt.file.write(options.hashFile, JSON.stringify(hashes));
+        }
+        else
+            grunt.log.writeln('Nothing changed.');
+
+    });
+};
+

--- a/static/images/pharmacy.svg
+++ b/static/images/pharmacy.svg
@@ -16,7 +16,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.47 r22583"
    sodipodi:docname="health_pharmacy.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/port.svg
+++ b/static/images/port.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="port.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/pub.svg
+++ b/static/images/pub.svg
@@ -15,7 +15,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.46"
    sodipodi:docname="amenity_pub.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata10">
     <rdf:RDF>

--- a/static/images/recycling.svg
+++ b/static/images/recycling.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="amenity_recycling.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/restaurant.svg
+++ b/static/images/restaurant.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
-<svg:svg
+<svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
@@ -13,7 +13,8 @@
    height="580"
    id="svg2"
    inkscape:version="0.48.1 r9760"
-   sodipodi:docname="food_restaurant.svg">
+   sodipodi:docname="food_restaurant.svg"
+   viewBox="0 0 580 580">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -34,7 +35,7 @@
      inkscape:window-y="0"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg2" />
-  <svg:metadata
+  <metadata
      id="metadata2975">
     <RDF>
       <Work
@@ -55,25 +56,25 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
       </cc:Work>
     </rdf:RDF>
-  </svg:metadata>
-  <svg:defs
+  </metadata>
+  <defs
      id="defs4" />
-  <svg:g
+  <g
      id="g1327">
-    <svg:path
+    <path
        d="M 66.275,1.768 C 24.94,1.768 1.704,23.139 1.704,66.804 l 0,450.123 c 0,40.844 20.894,62.229 62.192,62.229 l 452.024,0 c 41.307,0 62.229,-20.316 62.229,-62.229 l 0,-450.123 c 0,-42.601 -20.922,-65.036 -63.522,-65.036 -0.003,0 -448.494,-0.143 -448.352,0 z"
        style="fill:#111111;stroke:#eeeeee;stroke-width:3.40799999"
        id="path1329"
        inkscape:connector-curvature="0" />
-  </svg:g>
-  <svg:path
+  </g>
+  <path
      d="m 203.725,338.602 c 37.643,-17.466 64.864,-67.996 64.864,-127.642 0,-74.115 -61.834,-155.247 -93.849,-155.247 -32.014,0 -93.85,81.132 -93.85,155.247 0,59.646 27.223,110.176 64.865,127.642 l -7.792,176.545 73.553,0 -7.791,-176.545 z"
      style="fill:#ffffff"
      id="path2110"
      inkscape:connector-curvature="0" />
-  <svg:path
+  <path
      d="m 430.231,368.602 c 37.642,-17.466 51.389,-39.928 51.389,-99.574 L 471.839,66.214 c 0,-3.875 -3.142,-7.017 -7.018,-7.017 l -4.607,0 c -3.873,0 -7.016,3.141 -7.016,7.017 l 3.26,202.814 -20.259,0 -5.132,-204.789 c 0,-3.875 -3.142,-7.017 -7.018,-7.017 l -5.995,0 c -3.874,0 -7.016,3.142 -7.016,7.017 l 2.775,204.789 -25.137,0 2.775,-204.789 c 0,-3.875 -3.142,-7.017 -7.017,-7.017 l -5.996,0 c -3.875,0 -7.016,3.142 -7.016,7.017 l -5.132,204.789 -19.835,0 3.26,-202.789 c 0,-3.875 -3.142,-7.017 -7.017,-7.017 l -4.606,0 c -3.875,0 -7.018,3.142 -7.018,7.017 L 320.9,269.028 c 0,59.646 13.715,82.108 51.356,99.574 l -7.791,146.545 73.554,0 -7.788,-146.545 z"
      style="fill:#ffffff"
      id="path2112"
      inkscape:connector-curvature="0" />
-</svg:svg>
+</svg>

--- a/static/images/subway.svg
+++ b/static/images/subway.svg
@@ -16,7 +16,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.48.0 r9654"
    sodipodi:docname="transport_subway.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata10">
     <rdf:RDF>

--- a/static/images/supermarket.svg
+++ b/static/images/supermarket.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="supermarket.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/swimming_indoor.svg
+++ b/static/images/swimming_indoor.svg
@@ -17,7 +17,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.48.0 r9654"
    sodipodi:docname="sport_swimming_indoor.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata1976">
     <rdf:RDF>

--- a/static/images/taxi_rank.svg
+++ b/static/images/taxi_rank.svg
@@ -15,7 +15,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.46"
    sodipodi:docname="taxi_rank.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <defs
      id="defs22">
     <inkscape:perspective

--- a/static/images/toilets_men.svg
+++ b/static/images/toilets_men.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="toilets_men.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/train_station2.svg
+++ b/static/images/train_station2.svg
@@ -15,7 +15,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.46"
    sodipodi:docname="train_station2.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <defs
      id="defs22">
     <inkscape:perspective

--- a/static/images/tram_stop.svg
+++ b/static/images/tram_stop.svg
@@ -16,7 +16,8 @@
    inkscape:version="0.46"
    sodipodi:docname="tram_stop.svg"
    sodipodi:docbase="s:\Data\FacilityIcons"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/walking.svg
+++ b/static/images/walking.svg
@@ -16,7 +16,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.47 r22583"
    sodipodi:docname="transport_walking.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <metadata
      id="metadata2975">
     <rdf:RDF>

--- a/static/images/waste_bin.svg
+++ b/static/images/waste_bin.svg
@@ -15,7 +15,8 @@
    sodipodi:version="0.32"
    inkscape:version="0.46"
    sodipodi:docname="waste_bin.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   viewBox="0 0 580 580">
   <defs
      id="defs22">
     <inkscape:perspective


### PR DESCRIPTION
The pull request includes changes suggested by @juyrjola (https://github.com/ernoma/navigator-proto/commit/692bb0529470268f6fb868f49c0292ce0ff11c71). As @tuukka requested, there is now the icon task to generate png icons from svg icons only if there has been changes in the images directory. This might look a bit hack but it works well and maybe in future grunt will include a good way to do this (see: https://github.com/gruntjs/grunt/pull/851). Also, as @tuukka requested the class="citynavicon-myicon" is only applied after page has been created when iconprovider.modify_img_elements() is called. Icons now correctly show on Windows 8 phone. Tested with Nokia Lumia 520.
