### PR TITLE
Enables start with port option

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -73,7 +73,7 @@ module.exports = (grunt) ->
     connect:
       server:
         options:
-          port: 9001
+          port: grunt.option('port') || 9001
           base: "."
 
   grunt.loadNpmTasks 'grunt-contrib-coffee'


### PR DESCRIPTION
This enables givin port like so:
grunt server --port [port]